### PR TITLE
feat: add advanced calibration methods to remove horizontal striping

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -101,11 +101,13 @@ class CalibrationWorkerROI(QThread):
                 destripe_strength=0.9,
                 destripe_min_gain=0.8,
                 destripe_max_gain=1.2,
-                apply_row_destriping=False,
+                # Horizontal stripe suppression is needed for FX17 only.
+                apply_row_destriping=is_swir,
                 row_destripe_smooth_window=181 if is_swir else 121,
-                row_destripe_strength=0.92 if is_swir else 0.55,
-                row_destripe_min_gain=0.85,
-                row_destripe_max_gain=1.15,
+                row_destripe_strength=0.78 if is_swir else 0.55,
+                row_destripe_min_gain=0.92 if is_swir else 0.85,
+                row_destripe_max_gain=1.08 if is_swir else 1.15,
+                row_destripe_background_percentile=88.0 if is_swir else 75.0,
             )
         finally:
             # Capture output and restore stdout
@@ -320,7 +322,7 @@ class CalibApp(QWidget):
 
     def display_calibrated_image(self, image, wavelengths):
         """
-        Display the raw and calibrated hyperspectral images as RGB side by side.
+        Display raw and calibrated previews using the selected calibration run.
 
         Parameters:
         - image (np.ndarray): The calibrated hyperspectral data cube.
@@ -352,8 +354,29 @@ class CalibApp(QWidget):
             # SWIR false-color visualization (avoid non-existent 450nm channel)
             return (1600.0, 1300.0, 1050.0)
 
+        def cube_to_rgb(cube, wavs):
+            if wavs and len(wavs) > 0:
+                targets = rgb_targets_from_wavelengths(wavs)
+                red_idx = int(find_nearest_band(wavs, targets[0]))
+                green_idx = int(find_nearest_band(wavs, targets[1]))
+                blue_idx = int(find_nearest_band(wavs, targets[2]))
+
+                r = np.squeeze(robust_normalize_band(cube[:, :, red_idx]))
+                g = np.squeeze(robust_normalize_band(cube[:, :, green_idx]))
+                b = np.squeeze(robust_normalize_band(cube[:, :, blue_idx]))
+                rgb = np.stack([r, g, b], axis=-1)
+            else:
+                r = np.squeeze(normalize_image(cube[:, :, 60].astype(float)))
+                g = np.squeeze(normalize_image(cube[:, :, 30].astype(float)))
+                b = np.squeeze(normalize_image(cube[:, :, 10].astype(float)))
+                rgb = np.stack([r, g, b], axis=-1)
+
+            rgb = np.squeeze(rgb)
+            rgb = np.nan_to_num(rgb, nan=0.0, posinf=1.0, neginf=0.0)
+            return np.clip(rgb, 0.0, 1.0)
+
         try:
-            # Load raw image for comparison
+            # Load raw image for side-by-side comparison only.
             import spectral
 
             raw_img_data = spectral.open_image(self.raw_hdr)
@@ -380,63 +403,19 @@ class CalibApp(QWidget):
             except (TypeError, ValueError):
                 raw_wavelengths = []
 
-            # Extract RGB from raw image
-            if raw_wavelengths and len(raw_wavelengths) > 0:
-                raw_targets = rgb_targets_from_wavelengths(raw_wavelengths)
-                red_idx = int(find_nearest_band(raw_wavelengths, raw_targets[0]))
-                green_idx = int(find_nearest_band(raw_wavelengths, raw_targets[1]))
-                blue_idx = int(find_nearest_band(raw_wavelengths, raw_targets[2]))
+            raw_rgb = cube_to_rgb(raw_image, raw_wavelengths)
+            calibrated_rgb = cube_to_rgb(image, wavelengths)
 
-                raw_r = np.squeeze(robust_normalize_band(raw_image[:, :, red_idx]))
-                raw_g = np.squeeze(robust_normalize_band(raw_image[:, :, green_idx]))
-                raw_b = np.squeeze(robust_normalize_band(raw_image[:, :, blue_idx]))
-                raw_rgb = np.stack([raw_r, raw_g, raw_b], axis=-1)
-            else:
-                # Fallback: use band indices
-                raw_r = np.squeeze(normalize_image(raw_image[:, :, 60].astype(float)))
-                raw_g = np.squeeze(normalize_image(raw_image[:, :, 30].astype(float)))
-                raw_b = np.squeeze(normalize_image(raw_image[:, :, 10].astype(float)))
-                raw_rgb = np.stack([raw_r, raw_g, raw_b], axis=-1)
-
-            # Extract RGB from calibrated image
-            if wavelengths and len(wavelengths) > 0:
-                cal_targets = rgb_targets_from_wavelengths(wavelengths)
-                red_band_index = int(find_nearest_band(wavelengths, cal_targets[0]))
-                green_band_index = int(find_nearest_band(wavelengths, cal_targets[1]))
-                blue_band_index = int(find_nearest_band(wavelengths, cal_targets[2]))
-
-                cal_r = np.squeeze(robust_normalize_band(image[:, :, red_band_index]))
-                cal_g = np.squeeze(robust_normalize_band(image[:, :, green_band_index]))
-                cal_b = np.squeeze(robust_normalize_band(image[:, :, blue_band_index]))
-                calibrated_rgb = np.stack([cal_r, cal_g, cal_b], axis=-1)
-            else:
-                # Fallback: use band indices
-                cal_r = np.squeeze(normalize_image(image[:, :, 60].astype(float)))
-                cal_g = np.squeeze(normalize_image(image[:, :, 30].astype(float)))
-                cal_b = np.squeeze(normalize_image(image[:, :, 10].astype(float)))
-                calibrated_rgb = np.stack([cal_r, cal_g, cal_b], axis=-1)
-
-            # Normalize both to [0, 1]
-            raw_rgb = np.squeeze(raw_rgb)
-            raw_rgb = np.nan_to_num(raw_rgb, nan=0.0, posinf=1.0, neginf=0.0)
-            raw_rgb = np.clip(raw_rgb, 0.0, 1.0)
-
-            calibrated_rgb = np.squeeze(calibrated_rgb)
-            calibrated_rgb = np.nan_to_num(
-                calibrated_rgb, nan=0.0, posinf=1.0, neginf=0.0
-            )
-            calibrated_rgb = np.clip(calibrated_rgb, 0.0, 1.0)
-
-            # Display side by side using matplotlib
-            fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+            fig, axes = plt.subplots(1, 2, figsize=(16, 7))
+            for ax in axes:
+                ax.axis("off")
 
             axes[0].imshow(raw_rgb)
-            axes[0].set_title("Before: Raw Image", fontsize=14, fontweight="bold")
-            axes[0].axis("off")
-
+            axes[0].set_title("Raw", fontsize=14, fontweight="bold")
             axes[1].imshow(calibrated_rgb)
-            axes[1].set_title("After: Calibrated Image", fontsize=14, fontweight="bold")
-            axes[1].axis("off")
+            axes[1].set_title(
+                "Calibrated (Row+Col Separable)", fontsize=14, fontweight="bold"
+            )
 
             plt.tight_layout()
             plt.show()

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ import cv2
 from preprocessing.calibration import (
     white_dark_calibrate,
     white_dark_calibrate_from_rois,
+    destripe_cube_columns,
     select_coordinates,
     find_nearest_band,
     normalize_image,
@@ -63,12 +64,13 @@ class CalibrationWorkerROI(QThread):
     image_ready = pyqtSignal(np.ndarray, list)  # image and wavelengths
     output = pyqtSignal(str)  # for print output
 
-    def __init__(self, raw, white_roi, dark_roi, outdir):
+    def __init__(self, raw, white_roi, dark_roi, outdir, camera_type="fx10"):
         super().__init__()
         self.raw = raw
         self.white_roi = white_roi
         self.dark_roi = dark_roi
         self.outdir = outdir
+        self.camera_type = camera_type
 
     def run(self):
         import io
@@ -81,8 +83,29 @@ class CalibrationWorkerROI(QThread):
         sys.stdout = io.StringIO()
 
         try:
+            is_swir = self.camera_type == "fx17"
             calibrated = white_dark_calibrate_from_rois(
-                self.raw, self.white_roi, self.dark_roi, self.outdir
+                self.raw,
+                self.white_roi,
+                self.dark_roi,
+                self.outdir,
+                reference_method="row_col_separable",
+                smooth_window=31,
+                pre_destripe_raw=True,
+                pre_destripe_smooth_window=151,
+                pre_destripe_strength=0.85,
+                pre_destripe_min_gain=0.85,
+                pre_destripe_max_gain=1.15,
+                apply_column_destriping=True,
+                destripe_smooth_window=151,
+                destripe_strength=0.9,
+                destripe_min_gain=0.8,
+                destripe_max_gain=1.2,
+                apply_row_destriping=False,
+                row_destripe_smooth_window=181 if is_swir else 121,
+                row_destripe_strength=0.92 if is_swir else 0.55,
+                row_destripe_min_gain=0.85,
+                row_destripe_max_gain=1.15,
             )
         finally:
             # Capture output and restore stdout
@@ -164,7 +187,6 @@ class CalibApp(QWidget):
         # layout.addWidget(self.btn_remove_bg)
         # layout.addWidget(self.btn_save_bg_removal)
         # layout.addWidget(self.btn_analyze)
-       
 
         # --- Row 1: Run Calibration + Save Calibrated ---
         row1 = QHBoxLayout()
@@ -180,9 +202,8 @@ class CalibApp(QWidget):
         layout.addLayout(row1)
         layout.addLayout(row2)
 
-        # Analyze button below 
+        # Analyze button below
         layout.addWidget(self.btn_analyze)
-
 
         # Output text display
         self.output_text = QTextEdit()
@@ -285,7 +306,11 @@ class CalibApp(QWidget):
             return
 
         self.worker = CalibrationWorkerROI(
-            self.raw_hdr, self.white_roi, self.dark_roi, output_dir
+            self.raw_hdr,
+            self.white_roi,
+            self.dark_roi,
+            output_dir,
+            camera_type=self.camera_type,
         )
 
         self.worker.status.connect(self.append_output)
@@ -293,7 +318,6 @@ class CalibApp(QWidget):
         self.worker.output.connect(self.append_output)
         self.worker.start()
 
-        
     def display_calibrated_image(self, image, wavelengths):
         """
         Display the raw and calibrated hyperspectral images as RGB side by side.
@@ -309,6 +333,25 @@ class CalibApp(QWidget):
         self.calibrated_image = image
         self.calibrated_wavelengths = wavelengths
 
+        def robust_normalize_band(band, low=2.0, high=98.0):
+            band = np.asarray(band, dtype=float)
+            band = np.nan_to_num(band, nan=0.0, posinf=0.0, neginf=0.0)
+            lo, hi = np.percentile(band, [low, high])
+            if hi <= lo:
+                return np.zeros_like(band, dtype=float)
+            return np.clip((band - lo) / (hi - lo), 0.0, 1.0)
+
+        def rgb_targets_from_wavelengths(wavs):
+            if not wavs:
+                return None
+            wmin = float(min(wavs))
+            wmax = float(max(wavs))
+            # VNIR true-color-like visualization (FX10 can extend a little above 1000nm)
+            if wmin < 700 and wmax <= 1100:
+                return (660.0, 550.0, 470.0)
+            # SWIR false-color visualization (avoid non-existent 450nm channel)
+            return (1600.0, 1300.0, 1050.0)
+
         try:
             # Load raw image for comparison
             import spectral
@@ -316,6 +359,13 @@ class CalibApp(QWidget):
             raw_img_data = spectral.open_image(self.raw_hdr)
             # Use .load() to get the full array instead of slicing
             raw_image = raw_img_data.load()
+            raw_image = destripe_cube_columns(
+                raw_image,
+                smooth_window=151,
+                strength=0.85,
+                min_gain=0.85,
+                max_gain=1.15,
+            )
 
             # Safely extract wavelengths from metadata
             raw_wavelengths = []
@@ -332,19 +382,14 @@ class CalibApp(QWidget):
 
             # Extract RGB from raw image
             if raw_wavelengths and len(raw_wavelengths) > 0:
-                red_idx = int(find_nearest_band(raw_wavelengths, 660))
-                green_idx = int(find_nearest_band(raw_wavelengths, 550))
-                blue_idx = int(find_nearest_band(raw_wavelengths, 450))
+                raw_targets = rgb_targets_from_wavelengths(raw_wavelengths)
+                red_idx = int(find_nearest_band(raw_wavelengths, raw_targets[0]))
+                green_idx = int(find_nearest_band(raw_wavelengths, raw_targets[1]))
+                blue_idx = int(find_nearest_band(raw_wavelengths, raw_targets[2]))
 
-                raw_r = np.squeeze(
-                    normalize_image(raw_image[:, :, red_idx].astype(float))
-                )
-                raw_g = np.squeeze(
-                    normalize_image(raw_image[:, :, green_idx].astype(float))
-                )
-                raw_b = np.squeeze(
-                    normalize_image(raw_image[:, :, blue_idx].astype(float))
-                )
+                raw_r = np.squeeze(robust_normalize_band(raw_image[:, :, red_idx]))
+                raw_g = np.squeeze(robust_normalize_band(raw_image[:, :, green_idx]))
+                raw_b = np.squeeze(robust_normalize_band(raw_image[:, :, blue_idx]))
                 raw_rgb = np.stack([raw_r, raw_g, raw_b], axis=-1)
             else:
                 # Fallback: use band indices
@@ -355,19 +400,14 @@ class CalibApp(QWidget):
 
             # Extract RGB from calibrated image
             if wavelengths and len(wavelengths) > 0:
-                red_band_index = int(find_nearest_band(wavelengths, 660))
-                green_band_index = int(find_nearest_band(wavelengths, 550))
-                blue_band_index = int(find_nearest_band(wavelengths, 450))
+                cal_targets = rgb_targets_from_wavelengths(wavelengths)
+                red_band_index = int(find_nearest_band(wavelengths, cal_targets[0]))
+                green_band_index = int(find_nearest_band(wavelengths, cal_targets[1]))
+                blue_band_index = int(find_nearest_band(wavelengths, cal_targets[2]))
 
-                cal_r = np.squeeze(
-                    normalize_image(image[:, :, red_band_index].astype(float))
-                )
-                cal_g = np.squeeze(
-                    normalize_image(image[:, :, green_band_index].astype(float))
-                )
-                cal_b = np.squeeze(
-                    normalize_image(image[:, :, blue_band_index].astype(float))
-                )
+                cal_r = np.squeeze(robust_normalize_band(image[:, :, red_band_index]))
+                cal_g = np.squeeze(robust_normalize_band(image[:, :, green_band_index]))
+                cal_b = np.squeeze(robust_normalize_band(image[:, :, blue_band_index]))
                 calibrated_rgb = np.stack([cal_r, cal_g, cal_b], axis=-1)
             else:
                 # Fallback: use band indices
@@ -407,10 +447,11 @@ class CalibApp(QWidget):
             error_msg = f"Failed to display image: {str(e)}\n{traceback.format_exc()}"
             self.append_output(f"ERROR: {error_msg}")
             QMessageBox.warning(self, "Display Error", error_msg)
-        
+
         # Enable save button now that calibrated image is available
         self.btn_save_calib.setEnabled(True)
         self.btn_remove_bg.setEnabled(True)
+
     @staticmethod
     def resize_for_display_static(image, max_height=900):
         """
@@ -468,7 +509,6 @@ class CalibApp(QWidget):
         except Exception as e:
             self.append_output(f"ERROR: Background removal failed: {str(e)}")
 
-
     def save_calibrated_image(self):
         """Save calibrated image to user-selected directory."""
         if self.calibrated_image is None:
@@ -489,14 +529,14 @@ class CalibApp(QWidget):
             out_hdr = os.path.join(output_dir, f"{raw_basename}_calibrated.hdr")
             meta = spectral.open_image(self.raw_hdr).metadata
             meta["description"] = f"Calibrated using ROIs at {time.ctime()}"
-            #fix 1
+            # fix 1
             spectral.envi.save_image(
                 out_hdr,
                 self.calibrated_image,
                 dtype=np.float32,
                 interleave="bil",
                 force=True,
-                metadata=meta
+                metadata=meta,
             )
             self.append_output(f"Calibrated image saved to {out_hdr}")
             QMessageBox.information(
@@ -528,15 +568,14 @@ class CalibApp(QWidget):
 
             meta = spectral.open_image(self.raw_hdr).metadata
             meta["description"] = f"Background removed using method at {time.ctime()}"
-            #fix 2
+            # fix 2
             spectral.envi.save_image(
                 out_hdr,
                 self.plant_only,
                 dtype=np.float32,
                 interleave="bil",
                 force=True,
-                metadata=meta
-
+                metadata=meta,
             )
             self.append_output(f"Background-removed image saved to {out_hdr}")
             QMessageBox.information(
@@ -610,6 +649,7 @@ class CalibApp(QWidget):
             QMessageBox.warning(
                 self, "Display Error", f"Failed to display results: {str(e)}"
             )
+
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)

--- a/app/preprocessing/calibration.py
+++ b/app/preprocessing/calibration.py
@@ -5,6 +5,308 @@ import time
 import os
 
 
+def _extract_calibration_region(image, coordinates):
+    """Extract calibration ROI with bounds checks."""
+    rows_range = (int(coordinates[0, 1]), int(coordinates[2, 1]))  # Top to Bottom
+    cols_range = (int(coordinates[0, 0]), int(coordinates[1, 0]))  # Left to Right
+
+    rows_range = (max(0, rows_range[0]), min(image.shape[0], rows_range[1]))
+    cols_range = (max(0, cols_range[0]), min(image.shape[1], cols_range[1]))
+
+    region = image[rows_range[0] : rows_range[1], cols_range[0] : cols_range[1], :]
+    if region.size == 0:
+        raise ValueError("Calibration ROI is empty after bounds checking")
+    return region
+
+
+def _smooth_row_profiles(row_profiles, smooth_window=9):
+    """Smooth per-row spectra using an edge-padded moving average."""
+    if smooth_window <= 1 or row_profiles.shape[0] < 3:
+        return row_profiles
+
+    smooth_window = int(smooth_window)
+    if smooth_window % 2 == 0:
+        smooth_window += 1
+    smooth_window = min(smooth_window, row_profiles.shape[0])
+    if smooth_window % 2 == 0:
+        smooth_window -= 1
+    if smooth_window <= 1:
+        return row_profiles
+
+    kernel = np.ones(smooth_window, dtype=np.float64) / smooth_window
+    pad = smooth_window // 2
+    padded = np.pad(row_profiles, ((pad, pad), (0, 0)), mode="edge")
+    smoothed = np.apply_along_axis(
+        lambda col: np.convolve(col, kernel, mode="valid"),
+        axis=0,
+        arr=padded,
+    )
+    return smoothed
+
+
+def _smooth_1d_profile(profile, smooth_window=9):
+    """Smooth a 1D profile with an edge-padded moving average."""
+    if smooth_window <= 1 or profile.shape[0] < 3:
+        return profile
+
+    smooth_window = int(smooth_window)
+    if smooth_window % 2 == 0:
+        smooth_window += 1
+    smooth_window = min(smooth_window, profile.shape[0])
+    if smooth_window % 2 == 0:
+        smooth_window -= 1
+    if smooth_window <= 1:
+        return profile
+
+    kernel = np.ones(smooth_window, dtype=np.float64) / smooth_window
+    pad = smooth_window // 2
+    padded = np.pad(profile, (pad, pad), mode="edge")
+    return np.convolve(padded, kernel, mode="valid")
+
+
+def _destripe_columns_with_white_roi(
+    calibrated,
+    white_relative_coordinates,
+    smooth_window=151,
+    strength=0.9,
+    min_gain=0.8,
+    max_gain=1.2,
+    min_rows=32,
+):
+    """Reduce column-wise striping using white ROI statistics after calibration."""
+    if calibrated.ndim != 3:
+        return calibrated
+
+    h, _, b = calibrated.shape
+    row_start = max(0, min(h - 1, int(white_relative_coordinates[0, 1])))
+    row_end = max(0, min(h, int(white_relative_coordinates[2, 1])))
+    if row_end <= row_start:
+        row_end = min(h, row_start + 1)
+
+    current_rows = row_end - row_start
+    if current_rows < min_rows:
+        center = (row_start + row_end) // 2
+        half = min_rows // 2
+        row_start = max(0, center - half)
+        row_end = min(h, row_start + min_rows)
+        row_start = max(0, row_end - min_rows)
+
+    white_patch = calibrated[row_start:row_end, :, :].astype(np.float64, copy=False)
+    if white_patch.size == 0:
+        return calibrated
+
+    col_profile = np.median(white_patch, axis=0)  # (width, bands)
+    corrected = calibrated.astype(np.float64, copy=True)
+
+    for band_idx in range(b):
+        raw_col = col_profile[:, band_idx]
+        smooth_col = _smooth_1d_profile(raw_col, smooth_window=smooth_window)
+
+        gain = smooth_col / (raw_col + 1e-8)
+        gain = 1.0 + strength * (gain - 1.0)
+        gain = np.clip(gain, min_gain, max_gain)
+
+        corrected[:, :, band_idx] *= gain[np.newaxis, :]
+
+    corrected = np.clip(corrected, 0, 1)
+    return corrected.astype(calibrated.dtype, copy=False)
+
+
+def _destripe_rows_with_white_roi(
+    calibrated,
+    white_relative_coordinates,
+    smooth_window=181,
+    strength=0.9,
+    min_gain=0.85,
+    max_gain=1.15,
+    min_cols=64,
+):
+    """Reduce row-wise striping using white ROI statistics after calibration."""
+    if calibrated.ndim != 3:
+        return calibrated
+
+    h, w, b = calibrated.shape
+    col_start = max(0, min(w - 1, int(white_relative_coordinates[0, 0])))
+    col_end = max(0, min(w, int(white_relative_coordinates[1, 0])))
+    if col_end <= col_start:
+        col_end = min(w, col_start + 1)
+
+    current_cols = col_end - col_start
+    if current_cols < min_cols:
+        center = (col_start + col_end) // 2
+        half = min_cols // 2
+        col_start = max(0, center - half)
+        col_end = min(w, col_start + min_cols)
+        col_start = max(0, col_end - min_cols)
+
+    white_patch = calibrated[:, col_start:col_end, :].astype(np.float64, copy=False)
+    if white_patch.size == 0:
+        return calibrated
+
+    row_profile = np.median(white_patch, axis=1)  # (height, bands)
+    corrected = calibrated.astype(np.float64, copy=True)
+
+    for band_idx in range(b):
+        raw_row = row_profile[:, band_idx]
+        smooth_row = _smooth_1d_profile(raw_row, smooth_window=smooth_window)
+
+        gain = smooth_row / (raw_row + 1e-8)
+        gain = 1.0 + strength * (gain - 1.0)
+        gain = np.clip(gain, min_gain, max_gain)
+
+        corrected[:, :, band_idx] *= gain[:, np.newaxis]
+
+    corrected = np.clip(corrected, 0, 1)
+    return corrected.astype(calibrated.dtype, copy=False)
+
+
+def destripe_cube_columns(
+    cube,
+    reference_rows=None,
+    smooth_window=151,
+    strength=0.85,
+    min_gain=0.85,
+    max_gain=1.15,
+    min_rows=32,
+):
+    """Destripe a raw/calibrated cube by correcting column gain per band."""
+    if cube.ndim != 3:
+        return cube
+
+    h, _, b = cube.shape
+    if reference_rows is None:
+        patch = cube
+    else:
+        row_start = max(0, min(h - 1, int(reference_rows[0])))
+        row_end = max(0, min(h, int(reference_rows[1])))
+        if row_end <= row_start:
+            row_end = min(h, row_start + 1)
+
+        current_rows = row_end - row_start
+        if current_rows < min_rows:
+            center = (row_start + row_end) // 2
+            half = min_rows // 2
+            row_start = max(0, center - half)
+            row_end = min(h, row_start + min_rows)
+            row_start = max(0, row_end - min_rows)
+
+        patch = cube[row_start:row_end, :, :]
+
+    patch = patch.astype(np.float64, copy=False)
+    if patch.size == 0:
+        return cube
+
+    col_profile = np.median(patch, axis=0)  # (width, bands)
+    corrected = cube.astype(np.float64, copy=True)
+
+    for band_idx in range(b):
+        raw_col = col_profile[:, band_idx]
+        smooth_col = _smooth_1d_profile(raw_col, smooth_window=smooth_window)
+        gain = smooth_col / (raw_col + 1e-8)
+        gain = 1.0 + strength * (gain - 1.0)
+        gain = np.clip(gain, min_gain, max_gain)
+        corrected[:, :, band_idx] *= gain[np.newaxis, :]
+
+    return corrected.astype(cube.dtype, copy=False)
+
+
+def build_reference_from_roi(
+    image,
+    coordinates,
+    target_shape,
+    method="row_mean",
+    smooth_window=9,
+):
+    """
+    Build a full-size calibration reference from ROI using a configurable strategy.
+
+    Methods:
+    - replicate: Legacy vertical tiling of ROI (kept for comparison/backward compatibility)
+    - row_mean: Mean spectrum over ROI, broadcast over full image
+    - row_interp_smooth: Mean ROI spectrum per row, smoothed + interpolated over image rows
+    - row_col_separable: Smoothed row and column profiles combined per band
+    """
+    if method == "replicate":
+        return replicate_and_extend(image, coordinates, target_shape)
+
+    region = _extract_calibration_region(image, coordinates).astype(
+        np.float64, copy=False
+    )
+    target_h, target_w, target_b = target_shape
+
+    if method == "row_mean":
+        mean_spectrum = np.mean(region, axis=(0, 1), dtype=np.float64)
+        reference = np.broadcast_to(mean_spectrum.reshape(1, 1, -1), target_shape)
+        return reference.astype(image.dtype, copy=False)
+
+    if method == "row_interp_smooth":
+        row_profiles = np.mean(region, axis=1, dtype=np.float64)  # (roi_h, bands)
+        row_profiles = _smooth_row_profiles(row_profiles, smooth_window=smooth_window)
+
+        if row_profiles.shape[0] == 1:
+            interp_rows = np.repeat(row_profiles, target_h, axis=0)
+        else:
+            src_y = np.linspace(0, target_h - 1, row_profiles.shape[0])
+            tgt_y = np.arange(target_h)
+            interp_rows = np.empty((target_h, target_b), dtype=np.float64)
+            for band_idx in range(target_b):
+                interp_rows[:, band_idx] = np.interp(
+                    tgt_y, src_y, row_profiles[:, band_idx]
+                )
+
+        reference = np.broadcast_to(
+            interp_rows[:, np.newaxis, :], (target_h, target_w, target_b)
+        )
+        return reference.astype(image.dtype, copy=False)
+
+    if method == "row_col_separable":
+        # Separable model preserves detector column response and scan-line illumination.
+        row_profiles = np.mean(region, axis=1, dtype=np.float64)  # (roi_h, bands)
+        col_profiles = np.mean(region, axis=0, dtype=np.float64)  # (roi_w, bands)
+
+        row_profiles = _smooth_row_profiles(row_profiles, smooth_window=smooth_window)
+
+        interp_rows = np.empty((target_h, target_b), dtype=np.float64)
+        if row_profiles.shape[0] == 1:
+            interp_rows[:] = row_profiles[0]
+        else:
+            src_y = np.linspace(0, target_h - 1, row_profiles.shape[0])
+            tgt_y = np.arange(target_h)
+            for band_idx in range(target_b):
+                interp_rows[:, band_idx] = np.interp(
+                    tgt_y, src_y, row_profiles[:, band_idx]
+                )
+
+        interp_cols = np.empty((target_w, target_b), dtype=np.float64)
+        if col_profiles.shape[0] == 1:
+            interp_cols[:] = col_profiles[0]
+        else:
+            src_x = np.linspace(0, target_w - 1, col_profiles.shape[0])
+            tgt_x = np.arange(target_w)
+            for band_idx in range(target_b):
+                smoothed_col = _smooth_1d_profile(
+                    col_profiles[:, band_idx], smooth_window=smooth_window
+                )
+                interp_cols[:, band_idx] = np.interp(tgt_x, src_x, smoothed_col)
+
+        row_mean = np.mean(interp_rows, axis=0)
+        col_mean = np.mean(interp_cols, axis=0)
+        gain = np.where(col_mean == 0, 1.0, row_mean / (col_mean + 1e-12))
+        interp_cols *= gain[np.newaxis, :]
+
+        reference = (
+            interp_rows[:, np.newaxis, :]
+            + interp_cols[np.newaxis, :, :]
+            - row_mean[np.newaxis, np.newaxis, :]
+        )
+        reference = np.clip(reference, 0, None)
+        return reference.astype(image.dtype, copy=False)
+
+    raise ValueError(
+        f"Unknown reference method '{method}'. Use 'replicate', 'row_mean', 'row_interp_smooth', or 'row_col_separable'."
+    )
+
+
 def find_nearest_band(wavelengths, target_wavelength):
     """
     Find the index of the band with the wavelength closest to the target wavelength.
@@ -284,14 +586,41 @@ def white_dark_calibrate(raw_hdr, white_hdr, dark_hdr, outdir):
     meta = spectral.open_image(raw_hdr).metadata
     meta["description"] = f"Calibrated using ROIs at {time.ctime()}"
     spectral.envi.save_image(
-        calibrated_hdr, calibrated_cube, dtype=np.float32, interleave="bil", metadata=meta, force=True
+        calibrated_hdr,
+        calibrated_cube,
+        dtype=np.float32,
+        interleave="bil",
+        metadata=meta,
+        force=True,
     )
 
     print(f"Calibrated cube saved to {calibrated_hdr}")
     return calibrated_cube
 
 
-def white_dark_calibrate_from_rois(raw_hdr, white_roi, dark_roi, outdir):
+def white_dark_calibrate_from_rois(
+    raw_hdr,
+    white_roi,
+    dark_roi,
+    outdir,
+    reference_method="row_col_separable",
+    smooth_window=9,
+    pre_destripe_raw=True,
+    pre_destripe_smooth_window=151,
+    pre_destripe_strength=0.85,
+    pre_destripe_min_gain=0.85,
+    pre_destripe_max_gain=1.15,
+    apply_column_destriping=True,
+    destripe_smooth_window=151,
+    destripe_strength=0.9,
+    destripe_min_gain=0.8,
+    destripe_max_gain=1.2,
+    apply_row_destriping=False,
+    row_destripe_smooth_window=181,
+    row_destripe_strength=0.9,
+    row_destripe_min_gain=0.85,
+    row_destripe_max_gain=1.15,
+):
     """
     Perform white-dark calibration on a hyperspectral image cube using specified ROIs.
 
@@ -300,6 +629,23 @@ def white_dark_calibrate_from_rois(raw_hdr, white_roi, dark_roi, outdir):
     - white_roi: List of corner coordinates [(x1,y1), (x2,y2), (x3,y3), (x4,y4)]
     - dark_roi: List of corner coordinates [(x1,y1), (x2,y2), (x3,y3), (x4,y4)]
     - outdir: Directory to save the calibrated output cube
+    - reference_method: ROI reference construction strategy ('replicate', 'row_mean', 'row_interp_smooth', 'row_col_separable')
+    - smooth_window: Row smoothing window when using row_interp_smooth
+    - pre_destripe_raw: Enable column destriping on raw cropped cube before calibration
+    - pre_destripe_smooth_window: Column smoothing window for pre-calibration destriping
+    - pre_destripe_strength: Strength of pre-calibration gain correction [0, 1]
+    - pre_destripe_min_gain: Minimum allowed gain for pre-calibration destriping
+    - pre_destripe_max_gain: Maximum allowed gain for pre-calibration destriping
+    - apply_column_destriping: Enable post-calibration white-ROI-based column correction
+    - destripe_smooth_window: Column smoothing window for destriping profile
+    - destripe_strength: Strength of applied gain correction [0, 1]
+    - destripe_min_gain: Minimum allowed column gain during destriping
+    - destripe_max_gain: Maximum allowed column gain during destriping
+    - apply_row_destriping: Enable post-calibration row-wise stripe correction (off by default; can amplify scene texture)
+    - row_destripe_smooth_window: Row smoothing window for row destriping profile
+    - row_destripe_strength: Strength of applied row gain correction [0, 1]
+    - row_destripe_min_gain: Minimum allowed row gain during destriping
+    - row_destripe_max_gain: Maximum allowed row gain during destriping
 
     Returns:
     - calibrated: The calibrated hyperspectral image cube
@@ -317,11 +663,33 @@ def white_dark_calibrate_from_rois(raw_hdr, white_roi, dark_roi, outdir):
         )
     )
 
-    white_calibration_reference = replicate_and_extend(
-        cropped, white_calibration_relative_coordinates, cropped.shape
+    if pre_destripe_raw:
+        white_rows = (
+            int(white_calibration_relative_coordinates[0, 1]),
+            int(white_calibration_relative_coordinates[2, 1]),
+        )
+        cropped = destripe_cube_columns(
+            cropped,
+            reference_rows=white_rows,
+            smooth_window=pre_destripe_smooth_window,
+            strength=pre_destripe_strength,
+            min_gain=pre_destripe_min_gain,
+            max_gain=pre_destripe_max_gain,
+        )
+
+    white_calibration_reference = build_reference_from_roi(
+        cropped,
+        white_calibration_relative_coordinates,
+        cropped.shape,
+        method=reference_method,
+        smooth_window=smooth_window,
     )
-    dark_calibration_reference = replicate_and_extend(
-        cropped, dark_calibration_relative_coordinates, cropped.shape
+    dark_calibration_reference = build_reference_from_roi(
+        cropped,
+        dark_calibration_relative_coordinates,
+        cropped.shape,
+        method=reference_method,
+        smooth_window=smooth_window,
     )
 
     assert (
@@ -330,10 +698,36 @@ def white_dark_calibrate_from_rois(raw_hdr, white_roi, dark_roi, outdir):
         == dark_calibration_reference.shape
     ), "Shapes of cropped image and calibration references do not match."
 
-    calibrated = (cropped - dark_calibration_reference) / (
-        white_calibration_reference - dark_calibration_reference
+    denominator = white_calibration_reference - dark_calibration_reference
+    epsilon = 1e-6
+    denominator = np.where(
+        denominator >= 0,
+        np.maximum(denominator, epsilon),
+        np.minimum(denominator, -epsilon),
     )
+
+    calibrated = (cropped - dark_calibration_reference) / denominator
     calibrated = np.clip(calibrated, 0, 1)
+
+    if apply_column_destriping:
+        calibrated = _destripe_columns_with_white_roi(
+            calibrated,
+            white_calibration_relative_coordinates,
+            smooth_window=destripe_smooth_window,
+            strength=destripe_strength,
+            min_gain=destripe_min_gain,
+            max_gain=destripe_max_gain,
+        )
+
+    if apply_row_destriping:
+        calibrated = _destripe_rows_with_white_roi(
+            calibrated,
+            white_calibration_relative_coordinates,
+            smooth_window=row_destripe_smooth_window,
+            strength=row_destripe_strength,
+            min_gain=row_destripe_min_gain,
+            max_gain=row_destripe_max_gain,
+        )
 
     # Do not auto-save the ROI-calibrated cube here —
     # let the caller (GUI) decide when/where to save the result.

--- a/app/preprocessing/calibration.py
+++ b/app/preprocessing/calibration.py
@@ -120,6 +120,7 @@ def _destripe_rows_with_white_roi(
     min_gain=0.85,
     max_gain=1.15,
     min_cols=64,
+    background_percentile=80.0,
 ):
     """Reduce row-wise striping using white ROI statistics after calibration."""
     if calibrated.ndim != 3:
@@ -143,7 +144,9 @@ def _destripe_rows_with_white_roi(
     if white_patch.size == 0:
         return calibrated
 
-    row_profile = np.median(white_patch, axis=1)  # (height, bands)
+    # Use high-percentile background statistics to avoid plant pixels driving row gains.
+    p = float(np.clip(background_percentile, 50.0, 99.5))
+    row_profile = np.percentile(white_patch, p, axis=1)  # (height, bands)
     corrected = calibrated.astype(np.float64, copy=True)
 
     for band_idx in range(b):
@@ -620,6 +623,7 @@ def white_dark_calibrate_from_rois(
     row_destripe_strength=0.9,
     row_destripe_min_gain=0.85,
     row_destripe_max_gain=1.15,
+    row_destripe_background_percentile=80.0,
 ):
     """
     Perform white-dark calibration on a hyperspectral image cube using specified ROIs.
@@ -646,6 +650,7 @@ def white_dark_calibrate_from_rois(
     - row_destripe_strength: Strength of applied row gain correction [0, 1]
     - row_destripe_min_gain: Minimum allowed row gain during destriping
     - row_destripe_max_gain: Maximum allowed row gain during destriping
+    - row_destripe_background_percentile: Percentile used to estimate row background (higher reduces plant leakage)
 
     Returns:
     - calibrated: The calibrated hyperspectral image cube
@@ -727,6 +732,7 @@ def white_dark_calibrate_from_rois(
             strength=row_destripe_strength,
             min_gain=row_destripe_min_gain,
             max_gain=row_destripe_max_gain,
+            background_percentile=row_destripe_background_percentile,
         )
 
     # Do not auto-save the ROI-calibrated cube here —


### PR DESCRIPTION
## Stabilize ROI White–Dark Calibration and Fully Remove SWIR Horizontal Striping
### Fixes: #12

### Summary
This PR combines the earlier calibration refactor with the latest SWIR-specific destriping improvements.

The earlier work removed the dominant historical banding source (legacy replication artifacts), introduced robust reference construction and column destriping, and improved display consistency.  
The new commit completes the fix for residual SWIR horizontal striping by adding a robust FX17-only row correction strategy.

Current status:
1. VNIR outputs remain stable and clean.
2. SWIR horizontal striping is removed in the tested scenes.
3. Row+Col Separable is now the single default calibration method for both camera types.

### Problem Statement
1. Calibration originally showed strong banding artifacts.
2. Legacy periodic horizontal artifacts were reduced by the first refactor, but residual SWIR horizontal striping remained in some scenes.
3. Early row-correction attempts could introduce side artifacts near plant regions due to scene contamination.

### Root Cause Analysis
1. Legacy reference replication introduced row-periodic structure into full-height references.
2. White-dark normalization amplified residual row-wise gain mismatch in SWIR.
3. Column-only correction could not fully remove row-wise scan-line non-uniformity.

### What Was Implemented (Combined)
1. Reference construction refactor with configurable strategies:
    1. replicate (legacy comparison only)
    2. row_mean
    3. row_interp_smooth
    4. row_col_separable (best method, now default runtime method)

2. Safer calibration division:
    1. Epsilon-protected denominator to prevent instability when white-dark difference is near zero.

3. Column destriping stages:
    1. Pre-calibration raw column destriping.
    2. Post-calibration white-ROI-guided column destriping.

4. SWIR residual horizontal stripe fix (new commit):
    1. Enabled row destriping only for FX17 runs.
    2. Used background-focused high-percentile row statistics for row gain estimation, reducing plant leakage.
    3. Applied gentler FX17 row correction with tighter gain bounds to prevent side artifacts.

5. Deterministic runtime behavior:
    1. Worker uses explicit calibration parameters per camera type.
    2. Row+Col Separable is always used for final calibration output.

6. Visualization behavior update:
    1. Runtime plot no longer executes/displays all calibration methods.
    2. Plot now shows raw and final calibrated output only.

### Files Changed
1. calibration.py
2. main.py

### Behavior Changes
1. Calibration pipeline:
    1. Row+Col Separable is default for both VNIR and SWIR.
    2. Column destriping remains enabled pre and post calibration.
    3. Row destriping is applied only for FX17 with robust background-percentile profiling.

### Results
1. VNIR:
<img width="1862" height="976" alt="Screenshot from 2026-04-05 18-10-42" src="https://github.com/user-attachments/assets/cb994770-5db7-4278-8c87-bd3da8e1c9ec" />


2. SWIR:
<img width="1326" height="917" alt="image" src="https://github.com/user-attachments/assets/8300c005-3b2c-4182-ae82-f16dec13062e" />

